### PR TITLE
[ADD] Create initial scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+env:
+  global:
+    - DOCKER_REPO="laslabs/docker-quality-tools-test"
+    - DOCKER_USER="laslabsbot"
+    - DOCKER_TAG="latest"
+    - BRANCH_PROD=$TRAVIS_BRANCH
+    - secure: "PrlB5VIJlovOMgFt3oVT/7vAH/AGoerlNltsvaWpmYm/ffDNfRvWt7fViWur5nYCm/47HB+DqLU7dRprFWj4diF3WlFNrbAUZAfCrVDS/JbEHM17NNq/whsiuKQchbVZfSWbJgZmKWbdZ4OhhivdQlNCOOAHixqnC4XqK5e3IvGQ61xqPGzA9/0ITkxf2P/62GfZvJpHrzujvQzRx4n6z8RYPemvuLNP3KdvacqTgnoUQ203cEYe/OrAnS5XXMvsQcLoozwJVwRPEWGI+JhUNxJzZxtC2f2qYeaiPevnFr+opNPegkm1JFa2JWtYeUscgqurd7ny0t4IZjqMq9eEukgb/XBH+LSR0OHrJETBPAq2Lb5gnwN1S92JgvT7hyR6OoKoPQACuDN+1NYl5HvucdOI6FQDlmFb5pFESTEobii8rPrRgtJaEBz0/9oGUdCmOiVJw7sefxX0x3IYUPu16caWb7jL8hh8AGkIPuXwxJCr7YBvbw2TEp+xFa+gi6OBq6Q2QK+VEGtsJwIamO7qDA2uYT5I+1l9nAoI9wk6DS67KwL3kOMrr/SZWwV6cdmA+ranjO3Y2qexkBf15mX9uXP4PyW8wXbK1pTX9ghfhUZLKXkR6v5OS8fnRAyv8EJwMHBgRxaMo6RQc3xw7FYB8mmNOB50Hljg4UlWae74GVs="
+  matrix:
+    - TESTS="1" TEST_REPO="test_working_repo"
+    - TESTS="1" TEST_REPO="test_broken_repo" BROKEN="1"
+    - LINT_CHECK="1" TEST_REPO="test_working_repo"
+    - LINT_CHECK="1" TEST_REPO="test_broken_repo" BROKEN="1"
+    - HUB="1" TEST_REPO="test_working_repo"
+
+install:
+  - export PATH=${TRAVIS_BUILD_DIR}/travis:${PATH}
+  - export PATH=${TRAVIS_BUILD_DIR}/tests:${PATH}
+
+script:
+  - test_all "$TRAVIS_BUILD_DIR/tests/$TEST_REPO"

--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,25 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+The MIT License (MIT)
+=====================
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright 2016-TODAY LasLabs Inc.
 
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-  0. Additional Definitions.
-
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,15 @@
-|License LGPL-3|
+|License MIT| |Build Status|
 
 ====================
-Python Quality Tools
+Docker Quality Tools
 ====================
 
-This repo provides scripts primarily focused at peforming the following actions
-in a Continuous Integration server:
+This repo provides scripts primarily focused at performing the following actions
+in a Continuous Integration server for Docker repos:
 
 * Testing
-* Building & Deploying Documentation
+* Linting
+* Deploying to Dockerhub
 
 Usage
 =====
@@ -16,12 +17,18 @@ Usage
 This repo is meant to be called by a Continuous Integration server. A sample Travis
 file is included at ``sample_files/.travis.yml``.
 
+The test runner will automatically run any files matching the path ``./tests/test_*``.
+
+The environment variable ``DOCKER_CONTAINER_ID`` will be available to all tests, as well
+as all other environment variables that are available in other parts of the build.
+
 Known Issues / Road Map
 =======================
 
 -  Enhance ReadMe
--  Add tests
--  Try to centralize ``setup.py``, or add a sample one
+-  Add tests for Lint and Docker Hub
+-  Centralize and refactor
+-  Add some more test helpers
 
 Credits
 =======
@@ -38,6 +45,11 @@ Maintainer
    :alt: LasLabs Inc.
    :target: https://laslabs.com
 
-.. |License LGPL-3| image:: https://img.shields.io/badge/license-LGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/lgpl.html
-   :alt: License: LGPL-3
+This module is maintained by `LasLabs Inc. <https://laslabs.com>`_.
+
+.. |License MIT| image:: https://img.shields.io/badge/license-MIT-blue.svg
+   :target: https://opensource.org/licenses/MIT
+   :alt: License: MIT
+.. |Build Status| image:: https://api.travis-ci.org/LasLabs/docker-quality-tools.svg?branch=master
+   :target: https://travis-ci.org/LasLabs/docker-quality-tools
+   :alt: Build Status

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -1,0 +1,61 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+env:
+  global:
+    # These are for pushing to DockerHub
+    - DOCKER_REPO="laslabs/my-image"
+    - DOCKER_USER="laslabsbot"
+    - DOCKER_TAG="latest"
+    # Generate this per repo with the following:
+    #   travis encrypt '$DOCKER_PASS="$DOCKER_PASS"'-r LasLabs/repo-name
+    - secure: "$DOCKER_PASS_TOKEN"
+    # This is the branch where deploys happen
+    - BRANCH_PROD="master"
+    # Use this to change the Dockerfile location, relative to TRAVIS_BUILD_DIR
+    - DOCKERFILE="Dockerfile"
+    # This is a comma separated list of variables for build args, example:
+    #   PYTHON_VERSION=3,PYTHON_PACKAGE=python3
+    - BUILD_ARGS=""
+    # This is a comma separated list of port mappings, example:
+    #   80:80,443:443
+    - PORTS=""
+    # This is a comma separated list of link mappings, example:
+    #   postgres:db,nginx:proxy
+    - LINKS=""
+    # This indicates whether the image should be run as a daemon. "1" for Yes
+    #   or anything else for No.
+    - DAEMONIZE="1"
+    # This is a space separated list of arguments to add to the image when
+    #   issuing run.
+    - RUN_ARGS=""
+    # This is a comma separated list of environment variables to expose to the
+    #   docker container. Example:
+    #     ``POSTGRES_USER="psql",POSTGRES_PASS="SuperSecureBro"``
+    - RUN_ENV=""
+    # This is a comma separated list of lints to ignore
+    - LINT_IGNORE=""
+    # These could realistically all be excluded.
+    - TESTS="0"
+    - LINT_CHECK="0"
+    - HUB="0"
+
+  matrix:
+    - TESTS="1"
+    - LINT_CHECK="1"
+    - HUB="1"
+
+install:
+  - git clone --depth=1 https://github.com/LasLabs/docker-quality-tools.git ${HOME}/docker-quality-tools
+  - export PATH=${HOME}/docker-quality-tools/travis:${PATH}
+  - travis_install_all
+
+script:
+  - travis_run_all
+
+after_success:
+  - travis_after_success_all

--- a/sample_files/Dockerfile
+++ b/sample_files/Dockerfile
@@ -1,19 +1,18 @@
 FROM golang:alpine
 MAINTAINER LasLabs Inc <support@laslabs.com>
 
-# Install Build Dependencies & Application
-ENV BUILD_DEPS="build-base \
-                python-dev"
-
 # Make sure to use --no-cache.
-RUN apk add --no-cache "$BUILD_DEPS" \
-                       python
+RUN apk add --no-cache --virtual .build-deps \
+    build-base \
+    python-dev
+
+RUN apk add --no-cache python
 
 # Do stuff involving the build dependencies
-RUN echo "$BUILD_DEPS"
+RUN echo "Stuff"
 
 # Remove build dependencies
-RUN apk del "$BUILD_DEPS"
+RUN apk del .build-deps
 
 # Copy and define entrypoint
 COPY ./docker-entrypoint.sh /

--- a/sample_files/Dockerfile
+++ b/sample_files/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:alpine
+MAINTAINER LasLabs Inc <support@laslabs.com>
+
+# Install Build Dependencies & Application
+ENV BUILD_DEPS="build-base \
+                python-dev"
+
+# Make sure to use --no-cache.
+RUN apk add --no-cache "$BUILD_DEPS" \
+                       python
+
+# Do stuff involving the build dependencies
+RUN echo "$BUILD_DEPS"
+
+# Remove build dependencies
+RUN apk del "$BUILD_DEPS"
+
+# Copy and define entrypoint
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# This typically exposes the service that the container is responsible for.
+CMD ["python"]

--- a/sample_files/README.md
+++ b/sample_files/README.md
@@ -1,0 +1,66 @@
+[![License: MIT](https://img.shields.io/badge/licence-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/LasLabs/docker-repo.svg?branch=master)](https://travis-ci.org/LasLabs/docker-repo)
+
+Docker Image
+============
+
+This image provides something in Docker.
+
+Configuration
+=============
+
+*
+
+Usage
+=====
+
+* 
+
+Build Arguments
+===============
+
+The following build arguments are available for customization:
+
+
+| Name | Default | Description |
+|------|---------|-------------|
+
+
+Environment Variables
+=====================
+
+The following environment variables are available for your configuration
+pleasure:
+
+| Name | Default | Description |
+|------|---------|-------------|
+
+
+Known Issues / Roadmap
+======================
+
+*
+
+Bug Tracker
+===========
+
+Bugs are tracked on [GitHub Issues](https://github.com/LasLabs/docker-repo/issues).
+In case of trouble, please check there to see if your issue has already been reported.
+If you spotted it first, help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* My Name <my.email@example.com>
+
+Maintainer
+----------
+
+[![LasLabs Inc.](https://laslabs.com/logo.png)](https://laslabs.com)
+
+This module is maintained by [LasLabs Inc.](https://laslabs.com)
+
+* https://github.com/LasLabs/docker-repo

--- a/sample_files/docker-entrypoint.sh
+++ b/sample_files/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright 2017 LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+set -e
+
+COMMAND=ash
+
+# Add $COMMAND if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- $COMMAND "$@"
+fi
+
+# As argument is not related to $COMMAND,
+# then assume that user wants to run their own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/sample_files/tests/test_command_output
+++ b/sample_files/tests/test_command_output
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+# This script will test that EXPECT is in the output from COMMAND
+
+import os
+import subprocess
+
+COMMAND="openssl"
+EXPECT="OpenSSL> "
+
+cmd = 'docker exec -i -t %s %s' % (
+    os.environ.get('DOCKER_CONTAINER_ID'),
+    COMMAND
+)
+
+result = subprocess.check_output(cmd, shell=True)
+
+assert EXPECT in result

--- a/sample_files/tests/test_command_running
+++ b/sample_files/tests/test_command_running
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+# This script will test to see that $COMMAND is running on the Docker container.
+
+set -e
+
+# Change ``cat`` to be whatever command you are looking for in ``ps aux``
+COMMAND="cat"
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID ps aux`
+
+echo $OUTPUT | grep -q $COMMAND
+
+echo "$COMMAND is running on $DOCKER_CONTAINER_ID"

--- a/sample_files/tests/test_curl
+++ b/sample_files/tests/test_curl
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+curl --fail http://localhost:8096/web
+
+echo "Curl passed on $DOCKER_CONTAINER_ID"

--- a/sample_files/tests/test_entrypoint
+++ b/sample_files/tests/test_entrypoint
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+# This script will test that the entrypoint passes through commands.
+
+set -e
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID echo "test"`
+
+echo "Command in $DOCKER_CONTAINER_ID responded with:"
+echo $OUTPUT
+
+echo $OUTPUT | grep -q "test"

--- a/sample_files/tests/test_for_file
+++ b/sample_files/tests/test_for_file
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+# This script will test that $FILE_PATH exists on the server.
+
+set -e
+
+FILE_PATH='/docker-entrypoint.sh'
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID ls -l $FILE_PATH`
+
+echo $OUTPUT | grep -q "$FILE_PATH"
+
+echo "Container $DOCKER_CONTAINER_ID has file $FILE_PATH"

--- a/tests/test_all
+++ b/tests/test_all
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+import logging
+import os
+import subprocess
+import sys
+
+
+build_dir = os.environ.get('TRAVIS_BUILD_DIR', '.')
+
+
+def read_process(process):
+    collected = []
+    while True:
+        output = process.stdout.readline()
+        if output == '' and process.poll() is not None:
+            break
+        if output:
+            collected.append(output.strip())
+            logging.debug(collected[-1])
+        process.poll()
+    return '\n'.join(collected)
+
+
+def do_test(build_dir, env=None, add_env=None):
+
+    logging.info('Testing %s', build_dir)
+    if not env:
+        env = os.environ.copy()
+    env.update({
+        'TRAVIS_BUILD_DIR': build_dir,
+        'DAEMONIZE': '1',
+    })
+    if add_env:
+        env.update(add_env)
+
+    # Install Step
+    process = subprocess.Popen(
+        'travis_install_all',
+        shell=True,
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+    read_process(process)
+
+    # Test Step
+    process = subprocess.Popen(
+        'travis_run_all',
+        shell=True,
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+
+    try:
+        results = read_process(process)
+        fail = process.returncode
+    except (subprocess.CalledProcessError,
+            ValueError,
+            OSError):
+        logging.exception('%s encountered an error.', build_dir)
+        fail = True
+
+    if fail:
+        logging.error('Failures encountered during testing, exiting.')
+        logging.error('Results of command were:\n%s' % results)
+        exit(fail)
+    else:
+        logging.info('Test passed for %s', build_dir)
+
+    # After Success Step
+    process = subprocess.Popen(
+        'travis_after_success_all',
+        shell=True,
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+    read_process(process)
+
+
+if __name__ == '__main__':
+    """ Run tests specified by the command args. """
+
+    logging.basicConfig(format='%(levelname)s: %(message)s',
+                        level=logging.DEBUG)
+    logging.info('Start self test cycle')
+
+    fail = False
+
+    for test_dir in sys.argv[1:]:
+        env = os.environ.copy()
+        broken = env.get('BROKEN') or '_broken_' in test_dir
+        path = os.path.abspath(os.path.join(build_dir, test_dir))
+        env.update({
+            'BROKEN': str(int(broken)),
+        })
+        try:
+            do_test(path, env)
+            if broken:
+                logging.error('Test passed, but should have failed')
+                fail = True
+        except SystemExit:
+            if not broken:
+                logging.error('Test failed')
+                fail = True
+
+    exit(int(fail))

--- a/tests/test_broken_repo/Dockerfile
+++ b/tests/test_broken_repo/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.5
+MAINTAINER LasLabs Inc. <support@laslabs.com>
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+# Trigger a lint error
+RUN apk add --no-cache curl wget
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["cat"]

--- a/tests/test_broken_repo/README.md
+++ b/tests/test_broken_repo/README.md
@@ -1,0 +1,34 @@
+[![License: MIT](https://img.shields.io/badge/licence-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/LasLabs/docker-quality-tools.svg?branch=master)](https://travis-ci.org/LasLabs/docker-quality-tools)
+
+Broken Docker Image
+===================
+
+This image provides an Alpine image that is broken, in order to test
+[Docker Quality Tools](https://github.com/LasLabs/docker-quality-tools).
+
+Do not use this image for anything other than testing Docker Quality Tools.
+
+Bug Tracker
+===========
+
+Bugs are tracked on [GitHub Issues](https://github.com/LasLabs/docker-quality-tools/issues).
+In case of trouble, please check there to see if your issue has already been reported.
+If you spotted it first, help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+[![LasLabs Inc.](https://laslabs.com/logo.png)](https://laslabs.com)
+
+This module is maintained by [LasLabs Inc.](https://laslabs.com)
+
+* https://github.com/LasLabs/docker-quality-tools

--- a/tests/test_broken_repo/docker-entrypoint.sh
+++ b/tests/test_broken_repo/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright 2017 LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+COMMAND=cat
+
+set -e
+
+# Add $COMMAND if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- $COMMAND "$@"
+fi
+
+# As argument is not related to $COMMAND,
+# then assume that user wants to run their own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/tests/test_broken_repo/tests/test_command
+++ b/tests/test_broken_repo/tests/test_command
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID ps aux`
+
+echo "Command in $DOCKER_CONTAINER_ID responded with:"
+echo $OUTPUT
+
+echo $OUTPUT | grep -q "This is definitely not a running program!"

--- a/tests/test_broken_repo/tests/test_entrypoint
+++ b/tests/test_broken_repo/tests/test_entrypoint
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID ls /`
+
+echo "Command in $DOCKER_CONTAINER_ID responded with:"
+echo $OUTPUT
+
+echo $OUTPUT | grep -q "This is definitely not a folder on the root."

--- a/tests/test_working_repo/Dockerfile
+++ b/tests/test_working_repo/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.5
+MAINTAINER LasLabs Inc. <support@laslabs.com>
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["cat"]

--- a/tests/test_working_repo/README.md
+++ b/tests/test_working_repo/README.md
@@ -1,0 +1,34 @@
+[![License: MIT](https://img.shields.io/badge/licence-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/LasLabs/docker-quality-tools.svg?branch=master)](https://travis-ci.org/LasLabs/docker-quality-tools)
+
+Working Docker Image
+====================
+
+This image provides an Alpine image that works, in order to test
+[Docker Quality Tools](https://github.com/LasLabs/docker-quality-tools).
+
+Do not use this image for anything other than testing Docker Quality Tools.
+
+Bug Tracker
+===========
+
+Bugs are tracked on [GitHub Issues](https://github.com/LasLabs/docker-quality-tools/issues).
+In case of trouble, please check there to see if your issue has already been reported.
+If you spotted it first, help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+[![LasLabs Inc.](https://laslabs.com/logo.png)](https://laslabs.com)
+
+This module is maintained by [LasLabs Inc.](https://laslabs.com)
+
+* https://github.com/LasLabs/docker-quality-tools

--- a/tests/test_working_repo/docker-entrypoint.sh
+++ b/tests/test_working_repo/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright 2017 LasLabs Inc.
+# License MIT (https://opensource.org/licenses/MIT).
+
+COMMAND=cat
+
+set -e
+
+# Add $COMMAND if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- $COMMAND "$@"
+fi
+
+# As argument is not related to $COMMAND,
+# then assume that user wants to run their own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/tests/test_working_repo/tests/test_command
+++ b/tests/test_working_repo/tests/test_command
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID ps aux`
+
+echo "Command in $DOCKER_CONTAINER_ID responded with:"
+echo $OUTPUT
+
+echo $OUTPUT | grep -q "cat"

--- a/tests/test_working_repo/tests/test_entrypoint
+++ b/tests/test_working_repo/tests/test_entrypoint
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID echo "test"`
+
+echo "Command in $DOCKER_CONTAINER_ID responded with:"
+echo $OUTPUT
+
+echo $OUTPUT | grep -q "test"

--- a/tests/test_working_repo/tests/test_for_file
+++ b/tests/test_working_repo/tests/test_for_file
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+FILE_PATH='/docker-entrypoint.sh'
+
+# This script will test that $FILE_PATH exists on the server.
+
+OUTPUT=`docker exec -i -t $DOCKER_CONTAINER_ID ls -l $FILE_PATH`
+
+echo $OUTPUT | grep -q "$FILE_PATH"
+
+echo "Container $DOCKER_CONTAINER_ID has file $FILE_PATH"

--- a/travis/travis_after_success_all
+++ b/travis/travis_after_success_all
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+echo "Running After Install"
+
+if [ "${LINT_CHECK}" = "1" ]; 
+then
+
+  . travis_after_success_lint
+
+elif [ "${TESTS}" = "1" ]; 
+then
+
+  . travis_after_success_test
+
+elif [ "${DOCS}" = "1" ]; 
+then
+
+  if [ "${TRAVIS_BRANCH}" = "${BRANCH_PROD:=master}" ] \
+  && [ "${TRAVIS_PULL_REQUEST}" = "false" ];
+  then
+
+    . travis_after_success_doc
+
+  fi
+
+elif [ "${HUB}" = "1" ];
+then
+
+  if [ "${TRAVIS_BRANCH}" = "${BRANCH_PROD:=master}" ] \
+  && [ "${TRAVIS_PULL_REQUEST}" = "false" ];
+  then
+
+    . travis_after_success_hub
+
+  fi
+
+fi

--- a/travis/travis_after_success_hub
+++ b/travis/travis_after_success_hub
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+docker push $DOCKER_REPO:$DOCKER_TAG

--- a/travis/travis_after_success_lint
+++ b/travis/travis_after_success_lint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e

--- a/travis/travis_after_success_test
+++ b/travis/travis_after_success_test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e

--- a/travis/travis_build_image
+++ b/travis/travis_build_image
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+import os
+import subprocess
+
+build_dir = os.environ.get('TRAVIS_BUILD_DIR', os.path.dirname(__file__))
+docker_repo = os.environ.get('DOCKER_REPO', 'laslabs/docker-test')
+docker_tag = os.environ.get('DOCKER_TAG', 'latest')
+build_args = os.environ.get('BUILD_ARGS', [])
+if build_args:
+    build_args = build_args.split(',')
+
+build_args = [arg.strip() for arg in build_args]
+
+cmd = ['docker', 'build', '--tag=%s:%s' % (docker_repo, docker_tag)]
+
+for arg in build_args:
+    cmd.extend(('--build-arg', arg))
+
+cmd.append(build_dir)
+
+process = subprocess.Popen(
+  cmd, stdout=subprocess.PIPE, env=os.environ.copy(),
+)
+
+while True:
+    output = process.stdout.readline()
+    if output == '' and process.poll() is not None:
+        break
+    if output:
+        print output.strip()
+    rc = process.poll()
+
+exit(process.returncode)

--- a/travis/travis_install_all
+++ b/travis/travis_install_all
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+echo "Installing All Dependencies"
+
+# Fix Cert errors
+# pip install requests[security]
+
+# Now do the independent actions
+if [ "${LINT_CHECK}" = "1" ]; 
+then
+
+    . travis_install_lint
+
+elif [ "${TESTS}" = "1" ]; 
+then
+
+    . travis_install_test
+
+elif [ "${HUB}" = "1" ];
+then
+
+    if [ "${TRAVIS_BRANCH}" = "${BRANCH_PROD:=master}" ] \
+    && [ "${TRAVIS_PULL_REQUEST}" = "false" ];
+    then
+
+        . travis_install_hub
+
+    fi
+
+fi

--- a/travis/travis_install_hub
+++ b/travis/travis_install_hub
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+# Build Docker Image
+travis_build_image

--- a/travis/travis_install_lint
+++ b/travis/travis_install_lint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e

--- a/travis/travis_install_test
+++ b/travis/travis_install_test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+# Build Docker Image
+travis_build_image

--- a/travis/travis_run_all
+++ b/travis/travis_run_all
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+echo "Running Matrix Functions"
+
+if [ "${LINT_CHECK}" = "1" ]; 
+then
+
+    travis_run_lint
+
+elif [ "${TESTS}" = "1" ]; 
+then
+
+    travis_run_test
+
+elif [ "${HUB}" = "1" ];
+then
+
+    if [ "${TRAVIS_BRANCH}" = "${BRANCH_PROD:=master}" ] \
+    && [ "${TRAVIS_PULL_REQUEST}" = "false" ];
+    then
+
+        . travis_run_hub
+
+    fi
+
+fi

--- a/travis/travis_run_hub
+++ b/travis/travis_run_hub
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+set -e
+
+docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"

--- a/travis/travis_run_lint
+++ b/travis/travis_run_lint
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+import os
+import subprocess
+
+build_dir = os.environ.get('TRAVIS_BUILD_DIR', './')
+dockerfile = os.environ.get('DOCKERFILE', 'Dockerfile')
+lint_ignore = os.environ.get('LINT_IGNORE', [])
+
+if lint_ignore:
+    lint_ignore = lint_ignore.split(',')
+
+dockerfile_path = os.path.abspath('%s/%s' % (build_dir, dockerfile))
+
+cmd = ['docker', 'run', '--rm', '-i', 'lukasmartinelli/hadolint',
+       'hadolint']
+
+for ignore in lint_ignore:
+    cmd.extend(('--ignore', ignore))
+
+cmd.extend(['-', '<', '"%s"' % dockerfile_path])
+
+process = subprocess.Popen(
+  ' '.join(cmd), shell=True, stdout=subprocess.PIPE, env=os.environ.copy(),
+)
+
+while True:
+    output = process.stdout.readline()
+    if output == '' and process.poll() is not None:
+        break
+    if output:
+        print output.strip()
+    process.poll()
+
+exit(process.returncode)

--- a/travis/travis_run_test
+++ b/travis/travis_run_test
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 LasLabs Inc.
+# License MIT or later (https://opensource.org/licenses/MIT).
+
+import logging
+import os
+import subprocess
+
+logging.basicConfig(format='%(levelname)s: %(message)s',
+                    level=logging.DEBUG)
+
+build_number = os.environ.get('TRAVIS_BUILD_NUMBER', '0')
+build_dir = os.environ.get('TRAVIS_BUILD_DIR', './')
+daemonize = os.environ.get('DAEMONIZE', '1')
+docker_repo = os.environ.get('DOCKER_REPO', 'laslabs/docker-test')
+docker_tag = os.environ.get('DOCKER_TAG', 'latest')
+ports = os.environ.get('PORTS', [])
+links = os.environ.get('LINKS', [])
+run_env = os.environ.get('RUN_ENV', [])
+run_args = os.environ.get('RUN_ARGS', [])
+
+def read_process(process):
+    collected = []
+    while True:
+        output = process.stdout.readline()
+        if output == '' and process.poll() is not None:
+            break
+        if output:
+            collected.append(output.strip())
+            logging.debug(collected[-1])
+        process.poll()
+    return '\n'.join(collected)
+
+if ports:
+    ports = ports.split(',')
+
+if run_env:
+    run_env = run_env.split(',')
+
+if links:
+    links = links.split(',')
+
+if run_args:
+    run_args = run_args.split(' ')
+
+build_dir_absolute = os.path.abspath(build_dir)
+test_dir = os.path.join(build_dir_absolute, 'tests')
+
+cmd = ['docker', 'run', '--name=%s-%s' % (docker_tag, build_number)]
+
+for port in ports:
+    cmd.extend(('-p', port))
+
+for link in links:
+    cmd.append('--link=%s' % link)
+
+for env in run_env:
+    cmd.extend(('-e', env))
+
+if daemonize == '1':
+    cmd.append('-d')
+
+cmd.extend(['-t', "%s:%s" % (docker_repo, docker_tag)] + run_args)
+env = os.environ.copy()
+
+logging.debug(cmd)
+
+process = subprocess.Popen(
+  cmd, stdout=subprocess.PIPE, env=env,
+)
+env['DOCKER_CONTAINER_ID'] = read_process(process).strip()
+
+fail = False
+
+logging.debug(subprocess.check_call(['docker', 'ps']))
+logging.debug('Container ID %s', env['DOCKER_CONTAINER_ID'])
+
+if os.path.isdir(test_dir):
+    logging.debug('Test dir %s', test_dir)
+    for (dir_path, dirs, files) in os.walk(test_dir):
+        for file_name in files:
+            logging.debug('File %s', file_name)
+            if file_name.startswith('test_'):
+                file_path = os.path.join(dir_path, file_name)
+                logging.info('Beginning test on %s' % file_path)
+                process = subprocess.Popen(
+                    file_path,
+                    stdout=subprocess.PIPE,
+                    env=env,
+                )
+                read_process(process)
+                if process.returncode != 0:
+                    fail = True
+
+exit(fail)


### PR DESCRIPTION
Docker Quality Tools
====================

This repo provides scripts primarily focused at performing the following actions
in a Continuous Integration server for Docker repos:

* Testing
* Linting
* Deploying to Dockerhub ([test repo](https://hub.docker.com/r/laslabs/docker-quality-tools-test/) deployed from [this build](https://travis-ci.org/LasLabs/docker-quality-tools/jobs/189047057))

Usage
=====

This repo is meant to be called by a Continuous Integration server. A sample Travis
file is included at ``sample_files/.travis.yml``.

The test runner will automatically run any files matching the path ``./tests/test_*``.

The environment variable ``DOCKER_CONTAINER_ID`` will be available to all tests, as well
as all other environment variables that are available in other parts of the build.

Known Issues / Road Map
=======================

-  Enhance ReadMe
-  Add tests for Lint and Docker Hub
-  Centralize and refactor
-  Add some test helpers


cc @tedsalmon @yannickb @yajo @moylop260