### PR TITLE
[IMP] docker-quality-tools: Remove dotenv from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,6 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
-# dotenv
-.env
-
 # virtualenv
 venv/
 ENV/


### PR DESCRIPTION
Simple change - Remove `.env` since we're going to need to use them for default ENV variables.